### PR TITLE
Fix saving not fitted tf-idf vectorizer

### DIFF
--- a/metax.py
+++ b/metax.py
@@ -35,7 +35,8 @@ class XSSDetector:
 
         payloads = self.config['payload_injections']
         labels = [label_payload(payload) for payload in payloads]
-        X = TfidfVectorizer(max_features=30000, ngram_range=(1, 2)).fit_transform(payloads).toarray()
+        vectorizer = TfidfVectorizer(max_features=30000, ngram_range=(1, 2))
+        X = vectorizer.fit_transform(payloads).toarray()
 
         pipeline = Pipeline([
             ('clf', RandomForestClassifier(n_estimators=2000, max_depth=40, random_state=42))
@@ -52,7 +53,7 @@ class XSSDetector:
         logging.info(f"Model F1 score: {f1_score(y_test, y_pred)}")
 
         dump(best_pipeline, 'xss_model.joblib')
-        dump(TfidfVectorizer(max_features=30000, ngram_range=(1, 2)), 'tfidf_vectorizer.joblib')
+        dump(vectorizer, 'tfidf_vectorizer.joblib')
 
     def load_model(self):
         if not os.path.exists('xss_model.joblib') or not os.path.exists('tfidf_vectorizer.joblib'):


### PR DESCRIPTION
This pull request resolves the the tf-idf vectorizer is not fitted error by ensuring that the same instance of TfidfVectorizer is used both for fitting the data and for saving the vectorizer. This change eliminates the redundancy of creating a new vectorizer instance after fitting, which caused the error.

**Changes Made:**
- Removed the redundant creation of a new TfidfVectorizer instance.
- Ensured the fitted vectorizer is used consistently throughout the code.

**Testing:**
The changes were tested, and the program now runs successfully without the previous fitting error.

**Additional Notes:**
This fix should improve the stability of the model training process and ensure the vectorizer is properly fitted and saved for future use.